### PR TITLE
Add completion callback to execution context

### DIFF
--- a/engine/src/main/java/org/n52/javaps/algorithm/ProcessOutputs.java
+++ b/engine/src/main/java/org/n52/javaps/algorithm/ProcessOutputs.java
@@ -16,11 +16,11 @@
  */
 package org.n52.javaps.algorithm;
 
+import org.n52.javaps.io.Data;
+import org.n52.shetland.ogc.ows.OwsCode;
+
 import java.util.HashMap;
 import java.util.Map;
-
-import org.n52.shetland.ogc.ows.OwsCode;
-import org.n52.javaps.io.Data;
 
 /**
  * TODO JavaDoc
@@ -35,6 +35,10 @@ public class ProcessOutputs extends HashMap<OwsCode, Data<?>> {
 
     public ProcessOutputs(Map<? extends OwsCode, ? extends Data<?>> m) {
         super(m);
+    }
+
+    public ProcessOutputs(int initialCapacity) {
+        super(initialCapacity);
     }
 
 }

--- a/engine/src/main/java/org/n52/javaps/algorithm/annotation/AnnotatedAlgorithmMetadata.java
+++ b/engine/src/main/java/org/n52/javaps/algorithm/annotation/AnnotatedAlgorithmMetadata.java
@@ -16,6 +16,20 @@
  */
 package org.n52.javaps.algorithm.annotation;
 
+import com.google.common.base.Strings;
+import org.n52.janmayen.stream.MoreCollectors;
+import org.n52.janmayen.stream.Streams;
+import org.n52.javaps.description.TypedProcessDescription;
+import org.n52.javaps.description.TypedProcessInputDescription;
+import org.n52.javaps.description.TypedProcessOutputDescription;
+import org.n52.javaps.description.impl.TypedProcessDescriptionFactory;
+import org.n52.javaps.io.InputHandlerRepository;
+import org.n52.javaps.io.OutputHandlerRepository;
+import org.n52.javaps.io.literal.LiteralTypeRepository;
+import org.n52.shetland.ogc.ows.OwsCode;
+import org.n52.shetland.ogc.wps.description.ProcessInputDescription;
+import org.n52.shetland.ogc.wps.description.ProcessOutputDescription;
+
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
@@ -31,48 +45,26 @@ import java.util.Objects;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.stream.Collector;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.n52.janmayen.stream.MoreCollectors;
-import org.n52.janmayen.stream.Streams;
-import org.n52.javaps.description.TypedProcessDescription;
-import org.n52.javaps.description.TypedProcessInputDescription;
-import org.n52.javaps.description.TypedProcessOutputDescription;
-import org.n52.javaps.description.impl.TypedProcessDescriptionFactory;
-import org.n52.javaps.io.InputHandlerRepository;
-import org.n52.javaps.io.OutputHandlerRepository;
-import org.n52.javaps.io.literal.LiteralTypeRepository;
-import org.n52.shetland.ogc.ows.OwsCode;
-import org.n52.shetland.ogc.wps.description.ProcessInputDescription;
-import org.n52.shetland.ogc.wps.description.ProcessOutputDescription;
-
-import com.google.common.base.Strings;
-
 /**
- *
  * @author Tom Kunicki, Christian Autermann
  */
 public class AnnotatedAlgorithmMetadata {
 
     private static final String DUPLICATE_IDENTIFIER = "duplicated identifier: ";
-
     private final Class<?> algorithmClass;
-
     private final Map<OwsCode, AbstractOutputBinding<?>> outputBindings;
-
     private final Map<OwsCode, AbstractInputBinding<?>> inputBindings;
-
     private final ExecuteBinding executeBinding;
-
     private final TypedProcessDescription description;
-
     private final TypedProcessDescriptionFactory descriptionFactory;
 
     public AnnotatedAlgorithmMetadata(Class<?> algorithmClass, InputHandlerRepository parserRepository,
-            OutputHandlerRepository generatorRepository, LiteralTypeRepository literalTypeRepository) {
+                                      OutputHandlerRepository generatorRepository,
+                                      LiteralTypeRepository literalTypeRepository) {
         this.descriptionFactory = new TypedProcessDescriptionFactory();
-
-        // this.formatRepository = Objects.requireNonNull(formatRepository);
         this.algorithmClass = Objects.requireNonNull(algorithmClass);
 
         checkDefaultConstructor(algorithmClass);
@@ -92,26 +84,27 @@ public class AnnotatedAlgorithmMetadata {
     }
 
     private Map<OwsCode, AbstractOutputBinding<?>> getOutputBindings(Class<?> algorithmClass,
-            OutputHandlerRepository generatorRepository,
-            LiteralTypeRepository literalTypeRepository) {
-        Stream<AbstractOutputBinding<Field>> s1 = this.parseElements(getFields(algorithmClass),
+                                                                     OutputHandlerRepository generatorRepository,
+                                                                     LiteralTypeRepository literalTypeRepository) {
+        Stream<AbstractOutputBinding<Field>> s1 = this.parseElements(
+                getFields(algorithmClass),
                 Arrays.<AbstractOutputAnnotationParser<?, Field, AbstractOutputBinding<Field>>>asList(
-                new LiteralOutputAnnotationParser<>(AbstractOutputBinding::field, literalTypeRepository),
-                new ComplexOutputAnnotationParser<>(AbstractOutputBinding::field, generatorRepository),
-                new BoundingBoxOutputAnnotationParser<>(AbstractOutputBinding::field)))
-                .map(x -> (AbstractOutputBinding<Field>) x);
-        Stream<AbstractOutputBinding<Method>> s2 = parseElements(getMethods(algorithmClass),
+                        new LiteralOutputAnnotationParser<>(AbstractOutputBinding::field, literalTypeRepository),
+                        new ComplexOutputAnnotationParser<>(AbstractOutputBinding::field, generatorRepository),
+                        new BoundingBoxOutputAnnotationParser<>(AbstractOutputBinding::field)))
+                                                      .map(x -> (AbstractOutputBinding<Field>) x);
+        Stream<AbstractOutputBinding<Method>> s2 = parseElements(
+                getMethods(algorithmClass),
                 Arrays.<AbstractOutputAnnotationParser<?, Method, AbstractOutputBinding<Method>>>asList(
-                new LiteralOutputAnnotationParser<>(AbstractOutputBinding::method, literalTypeRepository),
-                new ComplexOutputAnnotationParser<>(AbstractOutputBinding::method, generatorRepository),
-                new BoundingBoxOutputAnnotationParser<>(AbstractOutputBinding::method)))
-                .map(x -> (AbstractOutputBinding<Method>) x);
+                        new LiteralOutputAnnotationParser<>(AbstractOutputBinding::method, literalTypeRepository),
+                        new ComplexOutputAnnotationParser<>(AbstractOutputBinding::method, generatorRepository),
+                        new BoundingBoxOutputAnnotationParser<>(AbstractOutputBinding::method)))
+                                                           .map(x -> (AbstractOutputBinding<Method>) x);
 
-        BinaryOperator<AbstractOutputBinding<?>> merger = org.n52.janmayen.stream.Streams.throwingMerger((a,
-                b) -> new RuntimeException(DUPLICATE_IDENTIFIER  + a.getDescription().getId()));
+        BinaryOperator<AbstractOutputBinding<?>> merger = Streams.throwingMerger(
+                (a, b) -> new RuntimeException(DUPLICATE_IDENTIFIER + a.getDescription().getId()));
         Collector<AbstractOutputBinding<?>, ?, Map<OwsCode, AbstractOutputBinding<?>>> collector =
-                java.util.stream.Collectors.toMap(b -> b.getDescription().getId(), java.util.function.Function
-                        .identity(), merger, LinkedHashMap::new);
+                Collectors.toMap(b -> b.getDescription().getId(), Function.identity(), merger, LinkedHashMap::new);
         return Collections.unmodifiableMap(Stream.concat(s1, s2).collect(collector));
     }
 
@@ -120,25 +113,26 @@ public class AnnotatedAlgorithmMetadata {
     }
 
     private Map<OwsCode, AbstractInputBinding<?>> getInputBindings(Class<?> algorithmClass,
-            InputHandlerRepository parserRepository,
-            LiteralTypeRepository literalTypeRepository) {
-        Stream<AbstractInputBinding<Field>> s1 = parseElements(getFields(algorithmClass),
+                                                                   InputHandlerRepository parserRepository,
+                                                                   LiteralTypeRepository literalTypeRepository) {
+        Stream<AbstractInputBinding<Field>> s1 = parseElements(
+                getFields(algorithmClass),
                 Arrays.<AbstractInputAnnotationParser<?, Field, AbstractInputBinding<Field>>>asList(
-                new LiteralInputAnnotationParser<>(AbstractInputBinding::field, literalTypeRepository),
-                new ComplexInputAnnotationParser<>(AbstractInputBinding::field, parserRepository),
-                new BoundingBoxInputAnnotationParser<>(AbstractInputBinding::field)))
-                .map(x -> (AbstractInputBinding<Field>) x);
-        Stream<AbstractInputBinding<Method>> s2 = parseElements(getMethods(algorithmClass),
+                        new LiteralInputAnnotationParser<>(AbstractInputBinding::field, literalTypeRepository),
+                        new ComplexInputAnnotationParser<>(AbstractInputBinding::field, parserRepository),
+                        new BoundingBoxInputAnnotationParser<>(AbstractInputBinding::field)))
+                                                         .map(x -> (AbstractInputBinding<Field>) x);
+        Stream<AbstractInputBinding<Method>> s2 = parseElements(
+                getMethods(algorithmClass),
                 Arrays.<AbstractInputAnnotationParser<?, Method, AbstractInputBinding<Method>>>asList(
-                new LiteralInputAnnotationParser<>(AbstractInputBinding::method, literalTypeRepository),
-                new ComplexInputAnnotationParser<>(AbstractInputBinding::method, parserRepository),
-                new BoundingBoxInputAnnotationParser<>(AbstractInputBinding::method)))
-                .map(x -> (AbstractInputBinding<Method>) x);
-        BinaryOperator<AbstractInputBinding<?>> merger = Streams.throwingMerger((a,
-                b) -> new RuntimeException(DUPLICATE_IDENTIFIER + a.getDescription().getId()));
+                        new LiteralInputAnnotationParser<>(AbstractInputBinding::method, literalTypeRepository),
+                        new ComplexInputAnnotationParser<>(AbstractInputBinding::method, parserRepository),
+                        new BoundingBoxInputAnnotationParser<>(AbstractInputBinding::method)))
+                                                          .map(x -> (AbstractInputBinding<Method>) x);
+        BinaryOperator<AbstractInputBinding<?>> merger = Streams.throwingMerger(
+                (a, b) -> new RuntimeException(DUPLICATE_IDENTIFIER + a.getDescription().getId()));
         Collector<AbstractInputBinding<?>, ?, LinkedHashMap<OwsCode, AbstractInputBinding<?>>> collector =
-                java.util.stream.Collectors.toMap(b -> b.getDescription().getId(), java.util.function.Function
-                        .identity(), merger, LinkedHashMap::new);
+                Collectors.toMap(b -> b.getDescription().getId(), Function.identity(), merger, LinkedHashMap::new);
         return Collections.unmodifiableMap(Stream.concat(s1, s2).collect(collector));
     }
 
@@ -148,10 +142,12 @@ public class AnnotatedAlgorithmMetadata {
 
     private ExecuteBinding getExecuteBinding(Class<?> algorithmClass) {
         ExecuteAnnotationParser parser = new ExecuteAnnotationParser();
-        return getMethods(algorithmClass).filter(method -> method.isAnnotationPresent(parser.getSupportedAnnotation()))
-                .map(method -> parser.parse(method)).filter(Objects::nonNull).collect(MoreCollectors.toSingleResult(
-                        () -> new RuntimeException("Multiple execute method bindings encountered for class "
-                                + algorithmClass.getCanonicalName())));
+        return getMethods(algorithmClass)
+                       .filter(method -> method.isAnnotationPresent(parser.getSupportedAnnotation()))
+                       .map(parser::parse).filter(Objects::nonNull)
+                       .collect(MoreCollectors.toSingleResult(
+                               () -> new RuntimeException("Multiple execute method bindings encountered for class "
+                                                          + algorithmClass.getCanonicalName())));
     }
 
     public TypedProcessDescription getDescription() {
@@ -159,35 +155,41 @@ public class AnnotatedAlgorithmMetadata {
     }
 
     private TypedProcessDescription getDescription(Class<?> algorithmClass,
-            Map<OwsCode, AbstractInputBinding<?>> inputBindings,
-            Map<OwsCode, AbstractOutputBinding<?>> outputBindings) {
+                                                   Map<OwsCode, AbstractInputBinding<?>> inputBindings,
+                                                   Map<OwsCode, AbstractOutputBinding<?>> outputBindings) {
         Function<AbstractInputBinding<?>, TypedProcessInputDescription<?>> getInputDescription =
                 AbstractInputBinding::getDescription;
-        List<ProcessInputDescription> inputs = inputBindings.values().stream().map(getInputDescription).collect(
-                java.util.stream.Collectors.toList());
+        List<ProcessInputDescription> inputs = inputBindings.values().stream().map(getInputDescription)
+                                                            .collect(Collectors.toList());
         Function<AbstractOutputBinding<?>, TypedProcessOutputDescription<?>> getOutputDescription =
                 AbstractOutputBinding::getDescription;
-        List<ProcessOutputDescription> outputs = outputBindings.values().stream().map(getOutputDescription).collect(
-                java.util.stream.Collectors.toList());
+        List<ProcessOutputDescription> outputs = outputBindings.values().stream().map(getOutputDescription)
+                                                               .collect(Collectors.toList());
         return getDescription(algorithmClass, inputs, outputs);
     }
 
     private TypedProcessDescription getDescription(Class<?> algorithmClass,
-            List<ProcessInputDescription> inputs,
-            List<ProcessOutputDescription> outputs) {
-        org.n52.javaps.algorithm.annotation.Algorithm annotation = getProcessAnnotation(algorithmClass);
+                                                   List<ProcessInputDescription> inputs,
+                                                   List<ProcessOutputDescription> outputs) {
+        Algorithm annotation = getProcessAnnotation(algorithmClass);
         String identifier = Strings.emptyToNull(annotation.identifier()) == null ? algorithmClass.getCanonicalName()
-                : annotation.identifier();
-        return descriptionFactory.process().withIdentifier(identifier).withTitle(annotation.title()).withAbstract(
-                annotation.abstrakt()).withVersion(annotation.version()).storeSupported(annotation.storeSupported())
-                .statusSupported(annotation.statusSupported()).withInput(inputs).withOutput(outputs).build();
+                                                                                 : annotation.identifier();
+        return descriptionFactory.process().withIdentifier(identifier)
+                                 .withTitle(annotation.title())
+                                 .withAbstract(annotation.abstrakt())
+                                 .withVersion(annotation.version())
+                                 .storeSupported(annotation.storeSupported())
+                                 .statusSupported(annotation.statusSupported())
+                                 .withInput(inputs).withOutput(outputs)
+                                 .build();
     }
 
-    public <M extends AccessibleObject & Member, B extends AbstractDataBinding<? super M, ?>> Stream<
-            ? extends B> parseElements(Stream<M> members,
-                    List<? extends AnnotationParser<?, M, ? extends B>> outputParser) {
-        return members.flatMap(member -> outputParser.stream().filter(parser -> member.isAnnotationPresent(parser
-                .getSupportedAnnotation())).map(parser -> parser.parse(member)).filter(Objects::nonNull));
+    public <M extends AccessibleObject & Member, B extends AbstractDataBinding<? super M, ?>> Stream<? extends B>
+    parseElements(Stream<M> members, List<? extends AnnotationParser<?, M, ? extends B>> outputParser) {
+        return members.flatMap(member -> outputParser
+                                                 .stream()
+                                                 .filter(p -> member.isAnnotationPresent(p.getSupportedAnnotation()))
+                                                 .map(p -> p.parse(member)).filter(Objects::nonNull));
     }
 
     private void checkDefaultConstructor(Class<?> algorithmClass) throws RuntimeException {
@@ -197,18 +199,17 @@ public class AnnotatedAlgorithmMetadata {
             if (!Modifier.isPublic(defaultConstructor.getModifiers())) {
                 throw new RuntimeException(
                         "Classes with Algorithm annotation require public no-arg constructor, error introspecting "
-                                + algorithmClass.getName());
+                        + algorithmClass.getName());
             }
         } catch (NoSuchMethodException | SecurityException ex) {
             throw new RuntimeException("Current security policy limits use of reflection, error introspecting "
-                    + algorithmClass.getName());
+                                       + algorithmClass.getName());
         }
     }
 
-    private org.n52.javaps.algorithm.annotation.Algorithm getProcessAnnotation(Class<?> algorithmClass1)
+    private Algorithm getProcessAnnotation(Class<?> algorithmClass1)
             throws RuntimeException {
-        org.n52.javaps.algorithm.annotation.Algorithm annotation = algorithmClass1.getAnnotation(
-                org.n52.javaps.algorithm.annotation.Algorithm.class);
+        Algorithm annotation = algorithmClass1.getAnnotation(Algorithm.class);
         if (annotation == null) {
             throw new RuntimeException("Class isn't annotated with an Algorithm annotation");
         }
@@ -225,7 +226,7 @@ public class AnnotatedAlgorithmMetadata {
 
     private Stream<Class<?>> getSuperTypeStream(Class<?> c) {
         return Stream.concat(Stream.of(c.getSuperclass()), Arrays.stream(c.getInterfaces())).filter(Objects::nonNull)
-                .flatMap(this::asClassStream).distinct();
+                     .flatMap(this::asClassStream).distinct();
     }
 
     private Stream<Class<?>> asClassStream(Class<?> clazz) {

--- a/engine/src/main/java/org/n52/javaps/engine/EngineProcessExecutionContext.java
+++ b/engine/src/main/java/org/n52/javaps/engine/EngineProcessExecutionContext.java
@@ -16,16 +16,15 @@
  */
 package org.n52.javaps.engine;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
 import org.n52.shetland.ogc.ows.OwsCode;
 import org.n52.shetland.ogc.wps.JobStatus;
 import org.n52.shetland.ogc.wps.OutputDefinition;
 import org.n52.shetland.ogc.wps.ResponseMode;
 import org.n52.shetland.ogc.wps.data.ProcessData;
-import org.n52.javaps.description.TypedProcessDescription;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 /**
  * TODO JavaDoc
@@ -39,8 +38,6 @@ public interface EngineProcessExecutionContext extends ProcessExecutionContext {
     ResponseMode getResponseMode();
 
     JobStatus getJobStatus();
-
-    TypedProcessDescription getDescription();
 
     Map<OwsCode, OutputDefinition> getOutputDefinitions();
 

--- a/engine/src/main/java/org/n52/javaps/engine/ProcessExecutionContext.java
+++ b/engine/src/main/java/org/n52/javaps/engine/ProcessExecutionContext.java
@@ -16,14 +16,15 @@
  */
 package org.n52.javaps.engine;
 
-import java.time.OffsetDateTime;
-import java.util.Optional;
-
+import org.n52.javaps.algorithm.ProcessInputs;
+import org.n52.javaps.algorithm.ProcessOutputs;
+import org.n52.javaps.description.TypedProcessDescription;
 import org.n52.shetland.ogc.ows.OwsCode;
 import org.n52.shetland.ogc.wps.JobId;
 import org.n52.shetland.ogc.wps.OutputDefinition;
-import org.n52.javaps.algorithm.ProcessInputs;
-import org.n52.javaps.algorithm.ProcessOutputs;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
 
 /**
  * TODO JavaDoc
@@ -50,6 +51,8 @@ public interface ProcessExecutionContext {
 
     void setNextPoll(OffsetDateTime nextPoll);
 
+    TypedProcessDescription getDescription();
+
     default boolean hasOutputDefinition(String output) {
         return hasOutputDefinition(new OwsCode(output));
     }
@@ -58,4 +61,10 @@ public interface ProcessExecutionContext {
         return getOutputDefinition(output).isPresent();
     }
 
+    /**
+     * Add an callback that is called once this {@link ProcessExecutionContext} is destroyed.
+     *
+     * @param runnable The {@link Runnable} to call.
+     */
+    void onDestroy(Runnable runnable);
 }


### PR DESCRIPTION
The callback is called once the process execution is completed. Most importantly this is done after all outputs are read by the `ResultPersistence` and the algorithm gets a chance to clean up afterwards.

The concrete usercase is a Docker container that stores all outputs in a single volume. If you don't want to load all outputs in memory after the container execution, but stream them directly though the `ResultPersistence`, you have to keep track how many outputs are already read by the `ResultPersistence` as the volume only can be deleted once the last output is read.