### PR TITLE
Deploy snapshots with travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,5 @@ jdk:
 cache:
   directories:
     - $HOME/.m2
-
+after_success:
+  - curl -Ls https://git.io/deploy-maven-snapshot | bash


### PR DESCRIPTION
This will deploy SNAPSHOTs from the `develop` branch to the Sonatype Snapshot repository. Credentials are managed in Travis [environment variables](https://travis-ci.org/github/52North/javaPS/settings).